### PR TITLE
Fix: Call to undefined function GuzzleHttp\Psr7\stream_for()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "require": {
         "php": "^7.2|^8.0",
         "guzzlehttp/guzzle": "~7.0",
+        "guzzlehttp/psr7": "^2.0",
         "guzzlehttp/uri-template": "0.2.0"
     },
 	"require-dev": {

--- a/src/Http/HapiClient.php
+++ b/src/Http/HapiClient.php
@@ -241,7 +241,7 @@ final class HapiClient implements HapiClientInterface
             $request->getMethod(),
             $url,
             array_merge($headers, $headersToAdd),
-            $body ? \GuzzleHttp\Psr7\streamFor($body) : null
+            $body ? \GuzzleHttp\Psr7\Utils::streamFor($body) : null
         );
 
         return $httpRequest;

--- a/src/Http/HapiClient.php
+++ b/src/Http/HapiClient.php
@@ -241,7 +241,7 @@ final class HapiClient implements HapiClientInterface
             $request->getMethod(),
             $url,
             array_merge($headers, $headersToAdd),
-            $body ? \GuzzleHttp\Psr7\stream_for($body) : null
+            $body ? \GuzzleHttp\Psr7\streamFor($body) : null
         );
 
         return $httpRequest;


### PR DESCRIPTION
The `stream_for()` function that is used by this library has been removed in `Guzzle\Psr7` which leads to the following error.

I've updated the function to use one suggested by [`Guzzle\Psr7` upgrade guide](https://github.com/guzzle/psr7#upgrading-from-function-api).

I've also listed `guzzlehttp/psr7` as dependency of this library as this package directly uses a function provided by `guzzlehttp/psr7`.

```
Error Call to undefined function GuzzleHttp\Psr7\stream_for() 
    vendor/slimpay/hapiclient-guzzle7/src/Http/HapiClient.php:244 HapiClient\Http\HapiClient::createHttpRequest
    vendor/slimpay/hapiclient-guzzle7/src/Http/HapiClient.php:115 HapiClient\Http\HapiClient::sendRequest
    vendor/slimpay/hapiclient-guzzle7/src/Http/Auth/Oauth2BasicAuthentication.php:169 HapiClient\Http\Auth\Oauth2BasicAuthentication::getAccessToken
    vendor/slimpay/hapiclient-guzzle7/src/Http/Auth/Oauth2BasicAuthentication.php:110 HapiClient\Http\Auth\Oauth2BasicAuthentication::authorizeRequest
    vendor/slimpay/hapiclient-guzzle7/src/Http/HapiClient.php:209 HapiClient\Http\HapiClient::createHttpRequest
    vendor/slimpay/hapiclient-guzzle7/src/Http/HapiClient.php:115 HapiClient\Http\HapiClient::sendRequest
    vendor/slimpay/hapiclient-guzzle7/src/Http/HapiClient.php:183 HapiClient\Http\HapiClient::getEntryPointResource
    vendor/slimpay/hapiclient-guzzle7/src/Http/HapiClient.php:154 HapiClient\Http\HapiClient::sendFollow
    ...
```

